### PR TITLE
remove mode from input

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ class CallUrl extends Extension {
 				label: 'URL to Call',
 				value: 'url-to-call',
 				icon: 'link',
-				mode: 'custom-value',
 				fontIcon: 'fas',
 				color: '#ff29df',
 				input: [


### PR DESCRIPTION
Fix the disappearing icon on board view. The `mode: 'custom-value'` will remove the icon and replace it with custom string value (see the [clock extension](https://github.com/rivafarabi/decboard-clock/blob/master/index.js))